### PR TITLE
Fix error `invalid_request` when perform request token

### DIFF
--- a/lib/flutter_appauth_web.dart
+++ b/lib/flutter_appauth_web.dart
@@ -158,7 +158,15 @@ class AppAuthWebPlugin extends FlutterAppAuthPlatform {
 
     if (request.additionalParameters != null) body.addAll(request.additionalParameters!);
 
-    final response = await http.post(Uri.parse(serviceConfiguration.tokenEndpoint), body: body);
+    final requestHeader = {
+     'Accept': 'application/json',
+    };
+
+    final response = await http.post(
+      Uri.parse(serviceConfiguration.tokenEndpoint),
+      headers: requestHeader,
+      body: body
+    );
 
     final Map<String, dynamic> jsonResponse = jsonDecode(response.body);
 


### PR DESCRIPTION
## Issue

I get a `400 Bad Request` error when trying to execute the `requestToken` method to get a new `accessToken`.
Response returned
```
{
     "error": "invalid_request"
}
```

## Solution 

- Add `Accept: application/json` to header